### PR TITLE
[FIX] l10n_ro_message_spv: facturi primite duplicate (invoice_validated)

### DIFF
--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -402,15 +402,23 @@ class MessageSPV(models.Model):
                             }
                         )
                 if not message.invoice_id.l10n_ro_edi_document_ids:
-                    if message.message_type != "error":
-                        state = "invoice_sent"
+                    if message.message_type in ("in_invoice", "in_receipt"):
+                        # Facturile primite se marchează invoice_validated, nu
+                        # invoice_sent. Core-ul l10n_ro_edi deduplică facturile
+                        # primite dupa l10n_ro_edi_state == 'invoice_validated';
+                        # cum starea e calculata din primul document EDI, daca
+                        # punem invoice_sent factura importata nu mai e gasita la
+                        # dedup, iar cronul de import o recreeaza (duplicat).
+                        edi_state = "invoice_validated"
+                    elif message.message_type == "error":
+                        edi_state = "invoice_refused"
                     else:
-                        state = "invoice_refused"
+                        edi_state = "invoice_sent"
 
                     self.env["l10n_ro_edi.document"].create(
                         {
                             "invoice_id": message.invoice_id.id,
-                            "state": state,
+                            "state": edi_state,
                         }
                     )
 


### PR DESCRIPTION
## Problemă

Facturile primite din SPV apăreau **duplicate**: una creată de core `l10n_ro_edi` (cron) și una creată de `l10n_ro_message_spv` la acțiunea de creare/legare factură. Pe una apărea starea EDI **Validat**, pe cealaltă **Trimis**.

## Cauză rădăcină

La crearea documentului EDI pentru o factură primită, modulul punea starea `invoice_sent`:

```python
if message.message_type != "error":
    state = "invoice_sent"
```

Core-ul `l10n_ro_edi` deduplică facturile primite după:

```python
Domain('l10n_ro_edi_index', 'in', [...])
& Domain('l10n_ro_edi_state', '=', 'invoice_validated')
```

Cum `l10n_ro_edi_state` e **calculat** din starea primului document EDI (`l10n_ro_edi_document_ids.sorted()[0].state`), setarea `invoice_sent` schimba starea calculată pe factură. Astfel factura deja importată **nu mai era recunoscută** la dedup, iar cronul de import o recrea → **duplicat**.

## Fix

Pentru mesajele `in_invoice`/`in_receipt`, documentul EDI se marchează acum `invoice_validated`, în acord cu starea pe care o pune core-ul la importul facturilor primite. Comportamentul pentru `out_*` (`invoice_sent`) și `error` (`invoice_refused`) rămâne neschimbat.

## Verificare

Reprodus pe `terrabit19` cu factura `M1-45139798` (CARGUS S.R.L.): o copie draft de la core (`invoice_validated`) + una postată `BILL/01290` de la modul (`invoice_sent`), ambele cu același `id_solicitare` ANAF `6420495402`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)