### PR TITLE
[FIX] l10n_ro_message_spv: allow deleting SPV bills with EDI document

### DIFF
--- a/l10n_ro_message_spv/models/account_move.py
+++ b/l10n_ro_message_spv/models/account_move.py
@@ -70,6 +70,15 @@ class AccountMove(models.Model):
         attachments += message_spv_ids.mapped("attachment_anaf_pdf_id")
         attachments += message_spv_ids.mapped("attachment_embedded_pdf_id")
         attachments.sudo().write({"res_id": False, "res_model": False})
+        # Facturile venite din SPV primesc un document l10n_ro_edi.document
+        # (vezi message_spv._confirm), al cărui invoice_id e required => ondelete
+        # restrict. El blocheaza stergerea facturii (ex. achizitie anulata adusa
+        # automat din SPV). Documentul e sintetic, creat doar pentru controlul
+        # dedup-ului; urma reala SPV ramane pe l10n.ro.message.spv + atasamente.
+        # Il curatam doar pentru facturile cu origine SPV, ca sa nu atingem
+        # documentele-audit ale facturilor proprii trimise la e-Factura.
+        spv_moves = self.filtered(lambda m: m.l10n_ro_message_spv_ids)
+        spv_moves.l10n_ro_edi_document_ids.sudo().unlink()
         return super().unlink()
 
     # def _get_edi_decoder(self, file_data, new=False):

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -141,11 +141,25 @@ class TestMessageSPV(TestMessageSPV):
         )
         message_spv.write({"invoice_id": invoice.id})
 
+        # Facturile primite din SPV primesc un l10n_ro_edi.document (vezi
+        # message_spv._confirm). invoice_id e required => ondelete restrict, deci
+        # documentul ar bloca stergerea facturii daca nu l-am curata in unlink.
+        edi_document = self.env["l10n_ro_edi.document"].create(
+            {
+                "invoice_id": invoice.id,
+                "state": "invoice_validated",
+            }
+        )
+
         # Verificăm că mesajul SPV este asociat cu factura
         self.assertEqual(invoice.l10n_ro_message_spv_ids[0].id, message_spv.id)
+        self.assertEqual(invoice.l10n_ro_edi_document_ids[0].id, edi_document.id)
 
-        # Ștergem factura
+        # Ștergem factura (nu trebuie să fie blocată de documentul EDI)
         invoice.unlink()
+
+        # Documentul EDI sintetic a fost curățat odată cu factura
+        self.assertFalse(edi_document.exists())
 
         # Verificăm că atașamentul nu mai este asociat cu niciun model/înregistrare
         self.assertFalse(attachment.res_id)


### PR DESCRIPTION
## Problemă

La Interheat nu se poate șterge o factură de achiziție **anulată** adusă automat dintr-un mesaj SPV. Eroare:

> Another model is using the record you are trying to delete. The troublemaker is: 'Document pentru urmărirea fișierelor XML CIUS-RO trimise către E-Factura' (l10n_ro_edi.document) ... constraint 'Factură' (invoice_id)

## Cauză

În 19.0, la confirmarea mesajului SPV, `message_spv._confirm` creează acum un `l10n_ro_edi.document` și pentru facturile **primite** (cu `state='invoice_validated'`, ca să nu intre cronul de import în buclă de duplicare — vezi comentariul din cod). Pe 18.0 nu se crea așa ceva pe achiziții.

`l10n_ro_edi.document.invoice_id` e `required=True` ⇒ `ondelete='restrict'`. Override-ul existent `account.move.unlink()` curăța doar `ir.attachment`-urile mesajului SPV, nu și documentul EDI ⇒ ștergerea era blocată.

## Fix

Completez `unlink()` să curețe și `l10n_ro_edi_document_ids` pentru facturile cu origine SPV, înainte de `super()`. Gardat pe `l10n_ro_message_spv_ids`, ca să nu atingem documentele-audit ale facturilor proprii trimise la e-Factura. Urma reală SPV rămâne pe `l10n.ro.message.spv` + atașamente.

## Test

Am extins `test_unlink_account_move` să creeze și un `l10n_ro_edi.document` pe factură (cum vine din SPV) și să verifice că ștergerea trece + documentul e curățat. Verde pe `test19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)