### PR TITLE
[IMP] l10n_ro_message_spv: scope SPV bill EDI-document purge to purchase draft/cancel

### DIFF
--- a/l10n_ro_message_spv/models/account_move.py
+++ b/l10n_ro_message_spv/models/account_move.py
@@ -70,14 +70,21 @@ class AccountMove(models.Model):
         attachments += message_spv_ids.mapped("attachment_anaf_pdf_id")
         attachments += message_spv_ids.mapped("attachment_embedded_pdf_id")
         attachments.sudo().write({"res_id": False, "res_model": False})
-        # Facturile venite din SPV primesc un document l10n_ro_edi.document
-        # (vezi message_spv._confirm), al cărui invoice_id e required => ondelete
-        # restrict. El blocheaza stergerea facturii (ex. achizitie anulata adusa
-        # automat din SPV). Documentul e sintetic, creat doar pentru controlul
-        # dedup-ului; urma reala SPV ramane pe l10n.ro.message.spv + atasamente.
-        # Il curatam doar pentru facturile cu origine SPV, ca sa nu atingem
-        # documentele-audit ale facturilor proprii trimise la e-Factura.
-        spv_moves = self.filtered(lambda m: m.l10n_ro_message_spv_ids)
+        # Facturile de achizitie venite din SPV primesc un document
+        # l10n_ro_edi.document (vezi message_spv._confirm), al carui invoice_id e
+        # required => ondelete restrict. El blocheaza stergerea facturii (ex.
+        # achizitie ciorna sau anulata adusa automat din SPV). Documentul e
+        # sintetic, creat doar pentru controlul dedup-ului; urma reala SPV ramane
+        # pe l10n.ro.message.spv + atasamente. Il curatam strict pentru facturile
+        # de achizitie (factura/nota de credit) cu origine SPV, aflate in ciorna
+        # sau anulate (singurele stari in care Odoo permite oricum stergerea), ca
+        # sa nu atingem documentele-audit ale facturilor proprii trimise la
+        # e-Factura.
+        spv_moves = self.filtered(
+            lambda m: m.l10n_ro_message_spv_ids
+            and m.move_type in ("in_invoice", "in_refund")
+            and m.state in ("draft", "cancel")
+        )
         spv_moves.l10n_ro_edi_document_ids.sudo().unlink()
         return super().unlink()
 

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -165,6 +165,34 @@ class TestMessageSPV(TestMessageSPV):
         self.assertFalse(attachment.res_id)
         self.assertFalse(attachment.res_model)
 
+    def test_unlink_cancelled_spv_bill(self):
+        """Factura de achiziție anulată adusă din SPV (cazul raportat) se poate
+        șterge chiar dacă are document EDI atașat."""
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "3006372782",
+                "company_id": self.env.company.id,
+                "message_type": "in_invoice",
+                "cif": "8486152",
+            }
+        )
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.vendor.id,
+            }
+        )
+        invoice.button_cancel()
+        self.assertEqual(invoice.state, "cancel")
+        message_spv.write({"invoice_id": invoice.id})
+        edi_document = self.env["l10n_ro_edi.document"].create(
+            {"invoice_id": invoice.id, "state": "invoice_validated"}
+        )
+
+        invoice.unlink()
+
+        self.assertFalse(edi_document.exists())
+
     def test_edi_transaction_tracking(self):
         """Testează câmpurile de urmărire a tranzacțiilor EDI"""
         # Creăm o factură


### PR DESCRIPTION
Urmare a [#19](https://github.com/terrabit-ro/l10n-romania/pull/19): restrâng curățarea documentului EDI din `unlink()` la cazurile care chiar o cer.

## Schimbare

Documentul EDI sintetic se purjează acum **doar** pentru:
- documente de **achiziție**: `move_type in ('in_invoice', 'in_refund')` (factură + notă de credit primită)
- în stare **ciornă sau anulată**: `state in ('draft', 'cancel')` — singurele stări în care Odoo permite oricum ștergerea unui `account.move`

Astfel, documentele-audit ale facturilor proprii trimise la e-Factura rămân neatinse.

## Test

Am adăugat `test_unlink_cancelled_spv_bill` (cazul raportat — factură de achiziție **anulată** din SPV), pe lângă cazul ciornă existent. Ambele verzi pe `test19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)