### PR TITLE
[FIX] l10n_ro_stock_account: gestiune corectă la transfer cu valoare 0

### DIFF
--- a/l10n_ro_stock_account/__manifest__.py
+++ b/l10n_ro_stock_account/__manifest__.py
@@ -1,7 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Romania - Stock Accounting",
-    "version": "18.0.1.24.0",
+    "version": "18.0.1.24.1",
     "category": "Localization",
     "countries": ["ro"],
     "summary": "Romania - Stock Accounting",

--- a/l10n_ro_stock_account/migrations/18.0.1.24.1/post-migration.py
+++ b/l10n_ro_stock_account/migrations/18.0.1.24.1/post-migration.py
@@ -1,0 +1,33 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Re-attribute the stock valuation account on zero-value layers.
+
+    Before this version ``_compute_account`` picked the source/destination
+    valuation account based on the *value* sign. Zero-value moves (e.g. a
+    100% discounted / free product) have value == 0 on every layer, so both
+    the out-leg and the in-leg ended up on the category default account,
+    leaving residual quantities on the per-account stock card. The compute
+    now keys on the *quantity* sign, so we recompute the stored
+    ``l10n_ro_account_id`` for the historical zero-value layers to fix the
+    stock card retroactively.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    layers = env["stock.valuation.layer"].search([("value", "=", 0)])
+    layers = layers.filtered(lambda sv: sv.stock_move_id.is_l10n_ro_record)
+    if not layers:
+        return
+    _logger.info(
+        "l10n_ro_stock_account: recomputing l10n_ro_account_id "
+        "for %s zero-value layers",
+        len(layers),
+    )
+    layers.invalidate_recordset(["l10n_ro_account_id"])
+    layers._compute_account()
+    layers.flush_recordset(["l10n_ro_account_id"])

--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -77,13 +77,20 @@ class StockValuationLayer(models.Model):
                 or svl.product_id.categ_id.property_stock_valuation_account_id
             )
             if svl.product_id.categ_id.l10n_ro_stock_account_change:
+                # Pick the source/destination valuation account based on the
+                # quantity sign, not the value sign. A zero-value move (e.g. a
+                # 100% discounted / free product) has value == 0 on both layers,
+                # so keying on ``value`` would leave both the out-leg and the
+                # in-leg on the category default account, breaking the per-account
+                # stock card (residual qty on both warehouses). The quantity sign
+                # always reflects the leg direction, including for value == 0.
                 if (
-                    svl.value > 0
+                    svl.quantity > 0
                     and loc_dest.l10n_ro_property_stock_valuation_account_id
                 ):
                     account = loc_dest.l10n_ro_property_stock_valuation_account_id
                 if (
-                    svl.value < 0
+                    svl.quantity < 0
                     and loc_scr.l10n_ro_property_stock_valuation_account_id
                 ):
                     account = loc_scr.l10n_ro_property_stock_valuation_account_id


### PR DESCRIPTION
## Problemă

La un transfer intern de marfă cu **valoare 0** (produs gratuit / discount 100%), pe **fișa de magazie pe gestiuni** rămân solduri reziduale: cantitate `+1`/`0 lei` pe gestiunea sursă și `-1`/`0 lei` pe gestiunea destinație, deși cantitatea netă este 0.

Raportat din producție (tichet **8751**, client DATUS/Agropiesa, Odoo 18): cartelă SIM achiziționată cu discount 100% (valoare finală 0), transferată intern `Mărfuri VL Engross (371011)` → `Alte materiale consumabile (302800)` și consumată — la 31.03.2026 rămân `+1/0` pe 371011 și `-1/0` pe 302800.

## Cauză

În `l10n_ro_stock_account/models/stock_valuation_layer.py`, `_compute_account` alegea contul de valorizare sursă/destinație după semnul **valorii** layerului:

```python
if svl.value > 0 ...: account = loc_dest...   # destinație
if svl.value < 0 ...: account = loc_scr...    # sursă
```

La valoare 0 niciuna din condiții nu e adevărată, deci **ambele** legi (descărcare și încărcare) rămân pe contul implicit al categoriei → descărcarea gestiunii sursă se pierde.

## Fix

Atribuirea cheie acum pe semnul **cantității** (`svl.quantity`), care reflectă mereu direcția legului, inclusiv la valoare 0. Pentru valori nenule comportamentul e identic (semnul valorii coincide cu cel al cantității).

Inclus și un **post-migration** (`18.0.1.24.1`) care recalculează câmpul stocat `l10n_ro_account_id` pe layerele istorice cu valoare 0, astfel încât fișa de magazie se corectează **retroactiv** la `-u l10n_ro_stock_account`.

## Verificare

Testat pe o copie a producției DATUS (`datus18`):
- înainte: descărcarea transferului SIM era atribuită pe 302800 (destinație) în loc de 371011 (sursă);
- după fix + post-migration: ambele gestiuni închid `0,00 / 0,00` la 31.03.2026;
- recalculul acoperă toate layerele cu valoare 0 (14 produse), nu doar cazul raportat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)