### PR TITLE
[FIX] l10n_ro_pos: raport Sale Details cu valoare de stoc, rescris pe stock.move (O19)

### DIFF
--- a/l10n_ro_pos/__init__.py
+++ b/l10n_ro_pos/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import report

--- a/l10n_ro_pos/__manifest__.py
+++ b/l10n_ro_pos/__manifest__.py
@@ -3,7 +3,7 @@
 # See README.rst file on addons root folder for license details
 {
     "name": "Romania - Point of Sale",
-    "version": "19.0.1.6.0",
+    "version": "19.0.1.7.0",
     "category": "Localization",
     "countries": ["ro"],
     "license": "AGPL-3",
@@ -11,6 +11,9 @@
     "website": "https://github.com/OCA/l10n-romania",
     "depends": ["point_of_sale", "l10n_ro_config"],
     "maintainers": ["dhongu", "cristianPanaite"],
+    "data": [
+        "views/report_saledetails.xml",
+    ],
     "assets": {
         "point_of_sale._assets_pos": [
             "l10n_ro_pos/static/src/**/*",

--- a/l10n_ro_pos/report/__init__.py
+++ b/l10n_ro_pos/report/__init__.py
@@ -1,0 +1,5 @@
+# ©  2015-2018 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from . import pos_order

--- a/l10n_ro_pos/report/pos_order.py
+++ b/l10n_ro_pos/report/pos_order.py
@@ -1,0 +1,113 @@
+# ©  2015-2021 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+
+from datetime import timedelta
+
+import pytz
+
+from odoo import api, fields, models
+
+
+class ReportSaleDetails(models.AbstractModel):
+    _inherit = "report.point_of_sale.report_saledetails"
+
+    @api.model
+    def get_sale_details(
+        self,
+        date_start=False,
+        date_stop=False,
+        config_ids=False,
+        session_ids=False,
+        **kwargs,
+    ):
+        res = super().get_sale_details(
+            date_start, date_stop, config_ids, session_ids, **kwargs
+        )
+
+        # Acelasi domeniu de comenzi ca raportul standard, ca sa calculam costul marfii.
+        # Conditii in AND implicit (liste concatenate); evitam osv.expression.AND,
+        # deprecat din 19.0 in favoarea odoo.fields.Domain.
+        domain = [("state", "in", ["paid", "invoiced", "done"])]
+
+        if session_ids:
+            domain += [("session_id", "in", session_ids)]
+        else:
+            if date_start:
+                date_start = fields.Datetime.from_string(date_start)
+            else:
+                # implicit: azi 00:00:00 in fusul orar al utilizatorului
+                user_tz = pytz.timezone(
+                    self.env.context.get("tz") or self.env.user.tz or "UTC"
+                )
+                today = user_tz.localize(
+                    fields.Datetime.from_string(fields.Date.context_today(self))
+                )
+                date_start = today.astimezone(pytz.timezone("UTC"))
+
+            if date_stop:
+                date_stop = fields.Datetime.from_string(date_stop)
+                # evitam un date_stop mai mic decat date_start
+                if date_stop < date_start:
+                    date_stop = date_start + timedelta(days=1, seconds=-1)
+            else:
+                # implicit: azi 23:59:59
+                date_stop = date_start + timedelta(days=1, seconds=-1)
+
+            domain += [
+                ("date_order", ">=", fields.Datetime.to_string(date_start)),
+                ("date_order", "<=", fields.Datetime.to_string(date_stop)),
+            ]
+
+            if config_ids:
+                domain += [("config_id", "in", config_ids)]
+
+        # Valoarea de stoc are sens doar cu valorizarea (stock_account) instalata;
+        # campul `value` pe stock.move vine de acolo. Daca lipseste, raportul ramane
+        # functional (coloanele afiseaza 0).
+        if "value" not in self.env["stock.move"]._fields:
+            res["total_stock_amount"] = 0.0
+            return res
+
+        orders = self.env["pos.order"].search(domain)
+
+        # In O19 SVL a fost eliminat; valorizarea e pe stock.move (value / quantity).
+        # Miscari valorizate = is_in/is_out (transferul intern nu e valorizat nativ).
+        # Acumulam valoare/cantitate per produs pentru un cost mediu unitar.
+        products_stock = {}
+        products_stock_qty = {}
+
+        for order in orders:
+            for picking in order.picking_ids:
+                for move in picking.move_ids:
+                    if not (move.is_in or move.is_out):
+                        continue
+                    products_stock.setdefault(move.product_id.id, 0.0)
+                    products_stock_qty.setdefault(move.product_id.id, 0.0)
+                    products_stock[move.product_id.id] += abs(move.value)
+                    products_stock_qty[move.product_id.id] += abs(move.quantity)
+
+        def _stock_price(product_id):
+            if product_id in products_stock and products_stock_qty.get(product_id):
+                return products_stock[product_id] / products_stock_qty[product_id]
+            return 0.0
+
+        # In Odoo 19 res["products"] / res["refund_products"] sunt liste de categorii,
+        # fiecare cu lista ei de produse. Injectam costul pe fiecare linie.
+        total_stock_amount = 0.0
+        for category in res.get("products", []):
+            for line in category.get("products", []):
+                stock_price = _stock_price(line.get("product_id"))
+                line["stock_price"] = stock_price
+                line["stock_amount"] = stock_price * line.get("quantity", 0.0)
+                total_stock_amount += line["stock_amount"]
+
+        for category in res.get("refund_products", []):
+            for line in category.get("products", []):
+                stock_price = _stock_price(line.get("product_id"))
+                line["stock_price"] = stock_price
+                line["stock_amount"] = stock_price * line.get("quantity", 0.0)
+
+        res["total_stock_amount"] = total_stock_amount
+        return res

--- a/l10n_ro_pos/tests/test_pos.py
+++ b/l10n_ro_pos/tests/test_pos.py
@@ -115,6 +115,91 @@ class TestReportPoSOrder(CommonPosTest):
             "Referința facturii trebuie să fie aceeași cu referința comenzii POS",
         )
 
+    def test_sale_details_stock_columns(self):
+        """Raportul Sale Details injecteaza cost unitar / valoare de stoc per produs."""
+        report = self.env["report.point_of_sale.report_saledetails"]
+
+        # Smoke: structura noua O19 + cheia de total, fara comenzi
+        res = report.get_sale_details()
+        self.assertIn("total_stock_amount", res)
+        self.assertIsInstance(res.get("products"), list)
+
+        # Seedam stoc (receptie 10 buc @ cost 60), ca iesirea sa fie valorizata
+        # si sa nu cadem pe constraintul de stoc negativ.
+        warehouse = self.company_data["default_warehouse"]
+        stock_location = warehouse.lot_stock_id
+        supplier_location = self.env.ref("stock.stock_location_suppliers")
+        receipt = self.env["stock.move"].create(
+            {
+                "product_id": self.product_a.id,
+                "product_uom": self.product_a.uom_id.id,
+                "product_uom_qty": 10.0,
+                "location_id": supplier_location.id,
+                "location_dest_id": stock_location.id,
+                "price_unit": 60.0,
+            }
+        )
+        receipt._action_confirm()
+        receipt._action_assign()
+        receipt.move_line_ids.quantity = 10.0
+        receipt.picked = True
+        receipt._action_done()
+
+        # Scenariu real: o comanda POS cu un produs cu cost
+        self.pos_config_usd.open_ui()
+        session = self.pos_config_usd.current_session_id
+        order_data = {
+            "amount_paid": 100.0,
+            "amount_return": 0,
+            "amount_tax": 0,
+            "amount_total": 100.0,
+            "date_order": "2024-01-01 10:00:00",
+            "name": "Order SD01",
+            "partner_id": self.ro_partner.id,
+            "session_id": session.id,
+            "lines": [
+                Command.create(
+                    {
+                        "product_id": self.product_a.id,
+                        "price_unit": 100.0,
+                        "qty": 2,
+                        "price_subtotal": 200.0,
+                        "price_subtotal_incl": 200.0,
+                    }
+                )
+            ],
+            "payment_ids": [
+                Command.create(
+                    {
+                        "amount": 100.0,
+                        "payment_method_id": self.cash_payment_method.id,
+                    }
+                )
+            ],
+            "uuid": "SD01",
+        }
+        self.env["pos.order"].sync_from_ui([order_data])
+
+        res = report.get_sale_details(session_ids=[session.id])
+        # Gasim linia produsului in structura grupata pe categorii
+        line = None
+        for category in res.get("products", []):
+            for product_line in category.get("products", []):
+                if product_line.get("product_id") == self.product_a.id:
+                    line = product_line
+                    break
+        self.assertIsNotNone(line, "Produsul vandut trebuie sa apara in raport")
+        # Cheile de stoc trebuie injectate pe fiecare linie
+        self.assertIn("stock_price", line)
+        self.assertIn("stock_amount", line)
+        # Cost mediu unitar din valorizarea miscarii de iesire (FIFO, receptie @ 60)
+        self.assertGreater(line["stock_price"], 0.0)
+        # stock_amount = cost unitar * cantitate vanduta
+        self.assertAlmostEqual(
+            line["stock_amount"], line["stock_price"] * line["quantity"], places=2
+        )
+        self.assertGreater(res["total_stock_amount"], 0.0)
+
     def test_session_accumulate_amounts(self):
         """Test that the amounts are accumulated correctly in the session."""
         self.pos_config_usd.open_ui()

--- a/l10n_ro_pos/views/report_saledetails.xml
+++ b/l10n_ro_pos/views/report_saledetails.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="pos_session_sales_details"
+        inherit_id="point_of_sale.pos_session_sales_details"
+    >
+        <!-- Rand categorie (Sales + Refunds): celule goale ca sa pastram alinierea coloanelor -->
+        <xpath expr="//tr[@t-as='category']" position="inside">
+            <td class="fw-bold" />
+            <td class="text-end fw-bold" />
+        </xpath>
+
+        <!-- Rand produs (Sales + Refunds): cost unitar din stoc + valoare stoc -->
+        <xpath expr="//tr[@t-as='line']" position="inside">
+            <td class="text-end">
+                <span
+                    t-out="line.get('stock_price', 0.0)"
+                    t-options="{'widget': 'float', 'precision': currency['precision']}"
+                >0.00</span>
+            </td>
+            <td class="text-end">
+                <span
+                    t-out="line.get('stock_amount', 0.0)"
+                    t-options="{'widget': 'float', 'precision': currency['precision']}"
+                >0.00</span>
+            </td>
+        </xpath>
+
+        <!-- Rand Total (sectiunea Sales): valoarea totala de stoc -->
+        <xpath
+            expr="//tr[td/strong/span[@t-out=&quot;products_info['qty']&quot;]]"
+            position="inside"
+        >
+            <td />
+            <td class="text-end">
+                <strong>
+                    <span
+                        t-out="total_stock_amount"
+                        t-options="{'widget': 'float', 'precision': currency['precision']}"
+                    >0.00</span>
+                </strong>
+            </td>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Context

Extensia raportului **„Sale Details"** (coloanele cu cost/valoare de stoc) s-a pierdut la migrarea 18.0 → 19.0. Versiunea 18.0 calcula costul din `move.stock_valuation_layer_ids` (**SVL**), care în Odoo 19 **a fost eliminat** — deci nu se putea face cherry-pick. Identificat la verificarea de drift a proiectului Primitiv (singurul gol real rămas pe `l10n_ro_pos`).

## Rescriere pe API-ul de valorizare O19

- `get_sale_details()` acumulează `abs(move.value)`/`abs(move.quantity)` peste mișcările pickingurilor comenzilor (guard `is_in`/`is_out`, fiindcă transferurile interne nu sunt valorizate nativ) → cost mediu unitar per produs.
- Injectează `stock_price` / `stock_amount` pe fiecare linie de produs din noua structură grupată pe categorii (`res["products"]` și `refund_products`) + `total_stock_amount`; template-ul adaugă coloanele corespunzătoare.
- **Degradare grațioasă** dacă `stock_account` nu e instalat (coloanele afișează 0) → nu adaugă o dependență grea.
- Domeniu construit prin concatenare de liste (AND implicit), nu prin `odoo.osv.expression.AND` (deprecat în 19.0).

## Out of scope (semnalat)

- `report/pos_invoice.py` din 18.0 (helper-e pentru un template de factură care nu e livrat în acest modul) — omis.
- `wizard/pos_payment.py` (preselecție cash) — `config_id.journal_ids` a fost eliminat în O19, comportamentul e acoperit nativ.
- Logica de cont venituri per locație (G1) — migrată corect în `l10n_ro_stock_account`, nu e regresie.

## Verificare

Test nou: seedează stoc @ cost, vinde prin `sync_from_ui`, verifică pe linia produsului `stock_price > 0`, `stock_amount = stock_price × qty` și `total_stock_amount > 0`, din valorizarea mișcării de ieșire. **Verde pe test19.** Modulul se instalează curat (xpath-ul de raport validat la load); pre-commit verde (ruff/pylint_odoo/prettier-xml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)