### PR TITLE
[IMP] l10n_ro_message_spv: anti-blocaj descărcare mesaje SPV

### DIFF
--- a/l10n_ro_message_spv/__manifest__.py
+++ b/l10n_ro_message_spv/__manifest__.py
@@ -16,7 +16,7 @@
         "wizard/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
-    "version": "19.0.1.19.0",
+    "version": "19.0.1.20.0",
     "author": "Terrabit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "installable": True,

--- a/l10n_ro_message_spv/models/message_spv.py
+++ b/l10n_ro_message_spv/models/message_spv.py
@@ -61,6 +61,8 @@ class MessageSPV(models.Model):
         ],
         default="draft",
     )
+    download_attempts = fields.Integer(default=0)
+    last_download_date = fields.Date()
     file_name = fields.Char()
     attachment_id = fields.Many2one("ir.attachment", string="Attachment")
     attachment_xml_id = fields.Many2one("ir.attachment", string="XML")
@@ -98,13 +100,24 @@ class MessageSPV(models.Model):
         session = requests.Session()
 
         for message in self.filtered(lambda m: not m.attachment_id):
-            # anaf_config = message.company_id.sudo()._l10n_ro_get_anaf_sync(
-            #     scope="e-factura"
-            # )
-            # if not anaf_config:
-            #     raise UserError(_("ANAF configuration is missing."))
+            today = fields.Date.today()
+            # La o redescărcare manuală a unui mesaj căzut în eroare repornim
+            # contorul de încercări de la zero.
+            if message.state == "error":
+                message.write(
+                    {
+                        "state": "draft",
+                        "download_attempts": 0,
+                        "last_download_date": False,
+                    }
+                )
 
-            # params = {"id": message.name}
+            # Numărăm încercările pe zi: dacă ultima descărcare a fost într-o zi
+            # anterioară, repornim contorul la 1.
+            attempts = message.download_attempts + 1
+            if message.last_download_date != today:
+                attempts = 1
+            message.write({"download_attempts": attempts, "last_download_date": today})
 
             response = self.env["l10n_ro_edi.document"]._request_ciusro_download_zip(
                 company=message.company_id,
@@ -115,11 +128,15 @@ class MessageSPV(models.Model):
             error = response.get("error", "")
 
             if error:
-                # Marcăm mesajul ca eroare ca să nu fie reselectat la infinit de
-                # cron (domeniul exclude state="error"). ANAF limitează la 10
-                # descărcări/zi pe mesaj; reîncercarea oarbă doar epuizează cota
-                # și spamează logul. Re-descărcarea se face manual de pe mesaj.
-                message.write({"error": str(error), "state": "error"})
+                # ANAF limitează la 10 descărcări/zi pe mesaj. Reîncercarea oarbă
+                # doar epuizează cota și spamează logul, așa că marcăm mesajul ca
+                # eroare după 3 încercări într-o zi - domeniul cron-ului exclude
+                # state="error", deci nu mai e reselectat în aceeași zi. Resetul
+                # zilnic error→draft din res.company îl readuce în coadă a doua zi.
+                vals = {"error": str(error)}
+                if message.download_attempts >= 3:
+                    vals["state"] = "error"
+                message.write(vals)
                 continue
             if message.message_type == "message":
                 info_message = message.check_anaf_message_xml(response["content"])

--- a/l10n_ro_message_spv/models/res_company.py
+++ b/l10n_ro_message_spv/models/res_company.py
@@ -29,18 +29,57 @@ class ResCompany(models.Model):
 
         need_retrigger = False
         for company in ro_companies:
+            # Resetăm la draft mesajele căzute în eroare în zilele trecute, ca să
+            # fie reîncercate (cota ANAF de 10 descărcări/zi/mesaj se reînnoiește).
+            error_messages_from_past = company.env["l10n.ro.message.spv"].search(
+                [
+                    ("company_id", "=", company.id),
+                    ("attachment_id", "=", False),
+                    ("state", "=", "error"),
+                    ("last_download_date", "<", fields.Date.today()),
+                ]
+            )
+            if error_messages_from_past:
+                error_messages_from_past.write(
+                    {"state": "draft", "download_attempts": 0}
+                )
+
+            # Procesăm mesajele în starea draft (state="error" rămâne exclus,
+            # deci un mesaj epuizat în ziua curentă nu mai e reselectat).
             domain = [
                 ("company_id", "=", company.id),
                 ("attachment_id", "=", False),
-                ("state", "!=", "error"),
+                ("state", "=", "draft"),
             ]
             messages = company.env["l10n.ro.message.spv"].search(
                 domain, limit=limit + 1
             )
             if len(messages) > limit:
                 need_retrigger = True
-                messages = messages[:limit]
-            messages.download_from_spv()
+
+            # Procesăm fiecare mesaj individual ca o eroare la unul să nu
+            # blocheze descărcarea celorlalte.
+            for message in messages[:limit]:
+                try:
+                    message.download_from_spv()
+                except Exception as e:  # pragma: no cover - protecție runtime
+                    _logger.exception(
+                        "Eroare la descărcarea ZIP pentru mesajul %s (compania %s)",
+                        message.name,
+                        company.id,
+                    )
+                    today = fields.Date.today()
+                    attempts = message.download_attempts + 1
+                    if message.last_download_date != today:
+                        attempts = 1
+                    message.sudo().write(
+                        {
+                            "state": "error",
+                            "error": str(e),
+                            "download_attempts": attempts,
+                            "last_download_date": today,
+                        }
+                    )
 
         if need_retrigger:
             self.env.ref(

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -6,8 +6,10 @@ import json
 import zipfile
 from unittest.mock import patch
 
+from dateutil.relativedelta import relativedelta
 from lxml import etree
 
+from odoo import fields
 from odoo.tests import tagged
 from odoo.tools.misc import file_path
 
@@ -80,6 +82,126 @@ class TestMessageSPV(TestMessageSPV):
         ):
             message_spv.download_from_spv()
             self.assertEqual(message_spv.error, "Invalid token")
+
+    def test_download_attempts_limit(self):
+        """Testează limitarea la 3 încercări de descărcare și trecerea
+        în starea de eroare"""
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "TEST_LIMIT",
+                "company_id": self.env.company.id,
+                "message_type": "in_invoice",
+            }
+        )
+
+        # Simulăm un răspuns cu eroare de la ANAF
+        error_response = {"error": "Limita de descărcări atinsă"}
+
+        with patch(
+            "odoo.addons.l10n_ro_message_spv.models.ciusro_document.make_efactura_request",
+            return_value=error_response,
+        ):
+            # Prima încercare
+            message_spv.download_from_spv()
+            self.assertEqual(message_spv.download_attempts, 1)
+            self.assertEqual(message_spv.state, "draft")
+
+            # A doua încercare
+            message_spv.download_from_spv()
+            self.assertEqual(message_spv.download_attempts, 2)
+            self.assertEqual(message_spv.state, "draft")
+
+            # A treia încercare -> starea devine eroare
+            message_spv.download_from_spv()
+            self.assertEqual(message_spv.download_attempts, 3)
+            self.assertEqual(message_spv.state, "error")
+
+    def test_download_attempts_daily_reset(self):
+        """Testează resetarea încercărilor de descărcare la schimbarea zilei"""
+        yesterday = fields.Date.today() - relativedelta(days=1)
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "TEST_RESET",
+                "company_id": self.env.company.id,
+                "message_type": "in_invoice",
+                "download_attempts": 2,
+                "last_download_date": yesterday,
+            }
+        )
+
+        # Simulăm un răspuns cu eroare
+        error_response = {"error": "Eroare temporară"}
+
+        with patch(
+            "odoo.addons.l10n_ro_message_spv.models.ciusro_document.make_efactura_request",
+            return_value=error_response,
+        ):
+            # Descărcarea astăzi ar trebui să reseteze încercările la 1
+            message_spv.download_from_spv()
+            self.assertEqual(message_spv.download_attempts, 1)
+            self.assertEqual(message_spv.last_download_date, fields.Date.today())
+
+    def test_cron_error_persistence_with_rollback(self):
+        """Testează dacă download_attempts este salvat de cron chiar
+        și în caz de excepție Python"""
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "TEST_ROLLBACK",
+                "company_id": self.env.company.id,
+                "state": "draft",
+                "download_attempts": 0,
+            }
+        )
+
+        # Forțăm o excepție în timpul download_from_spv pentru a verifica
+        # că eroarea este capturată și persistată de cron.
+        with self.assertLogs(
+            "odoo.addons.l10n_ro_message_spv.models.res_company", level="ERROR"
+        ) as cm:
+            with patch.object(
+                type(self.env["l10n.ro.message.spv"]),
+                "download_from_spv",
+                side_effect=Exception("Crash!"),
+            ):
+                self.env.company.l10n_ro_download_zip_message_spv(limit=1)
+
+            self.assertTrue(
+                any("Eroare la descărcarea ZIP" in log for log in cm.output)
+            )
+
+        # În ciuda crash-ului, cron-ul a salvat eroarea și a incrementat încercările
+        message_spv.invalidate_recordset()
+        self.assertEqual(message_spv.state, "error")
+        self.assertEqual(message_spv.download_attempts, 1)
+        self.assertIn("Crash!", message_spv.error)
+
+    def test_cron_daily_reset_error_to_draft(self):
+        """Testează resetul zilnic error→draft din cron pentru mesajele
+        căzute în eroare în zilele trecute"""
+        yesterday = fields.Date.today() - relativedelta(days=1)
+        message_spv = self.env["l10n.ro.message.spv"].create(
+            {
+                "name": "TEST_DAILY_RESET",
+                "company_id": self.env.company.id,
+                "message_type": "in_invoice",
+                "state": "error",
+                "download_attempts": 3,
+                "last_download_date": yesterday,
+            }
+        )
+
+        file_invoice = file_path("l10n_ro_message_spv/tests/invoice.zip")
+        zip_content = {"content": open(file_invoice, "rb").read()}
+        with patch(
+            "odoo.addons.l10n_ro_message_spv.models.ciusro_document.make_efactura_request",
+            return_value=zip_content,
+        ):
+            self.env.company.l10n_ro_download_zip_message_spv(limit=5)
+
+        # Mesajul a fost readus în coadă, descărcat și contorul reluat de la 1
+        self.assertEqual(message_spv.state, "downloaded")
+        self.assertTrue(message_spv.attachment_id)
+        self.assertEqual(message_spv.download_attempts, 1)
 
     def test_download_from_spv(self):
         # test descarcare zip from SPV


### PR DESCRIPTION
## Context

Pe **18.0** (v18.0.1.21.0) metoda `res.company.l10n_ro_download_zip_message_spv` are logica completă de anti-blocaj pentru descărcarea mesajelor SPV. Pe **19.0** exista doar fix-ul simplu `state != 'error'` în domeniul cron-ului ([63aef6455]) — lipsea resetul zilnic `error→draft` și câmpul `download_attempts`, deci **un mesaj căzut pe cota zilnică ANAF (10 descărcări/zi/mesaj) rămânea blocat permanent în `error` și nu mai era reîncercat**.

## Modificări (port 18.0 → 19.0)

- **Model `l10n.ro.message.spv`**: câmpuri noi `download_attempts` (Integer) și `last_download_date` (Date).
- **`download_from_spv`**: numără încercările pe zi (reset la 1 la schimbarea zilei) și marchează `state="error"` abia după **3 încercări într-o zi**, nu de la prima eroare; la o redescărcare manuală a unui mesaj în eroare repornește contorul.
- **`l10n_ro_download_zip_message_spv`** (cron): resetează zilnic `error→draft` mesajele căzute în zilele trecute (cota ANAF se reînnoiește) și procesează fiecare mesaj **individual cu try/except**, ca o eroare la unul să nu blocheze restul.

## Teste

Adăugate (toate cele 23 de teste ale modulului trec local pe `test19`):
- `test_download_attempts_limit` — 3 încercări → `error`
- `test_download_attempts_daily_reset` — reset contor la zi nouă
- `test_cron_error_persistence_with_rollback` — eroarea din cron e persistată
- `test_cron_daily_reset_error_to_draft` — reset zilnic `error→draft` din cron

Versiune manifest: `19.0.1.19.0` → `19.0.1.20.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)