### PR TITLE
[FIX] l10n_ro_stock_account: match aggregated account balance, not single line

### DIFF
--- a/l10n_ro_stock_account/models/stock_valuation_layer.py
+++ b/l10n_ro_stock_account/models/stock_valuation_layer.py
@@ -97,13 +97,24 @@ class StockValuationLayer(models.Model):
             if svl.account_move_id and (
                 not svl.l10n_ro_valued_type or "internal" not in svl.l10n_ro_valued_type
             ):
-                for aml in svl.account_move_id.line_ids.sorted(
-                    lambda layer: layer.account_id.code or ""
-                ):
+                # Some postings (e.g. landed costs split between capitalizing on
+                # remaining stock and expensing to 607 the part already sold)
+                # impact the SAME stock account through several lines whose
+                # individual balances don't match ``svl.value`` on their own,
+                # only their sum does. Matching a single line misses this case
+                # and silently falls back to the category's default account,
+                # leaving a stock-card residual on the correct account. Group
+                # class 2/3 lines by account and match on the aggregated balance.
+                by_account = {}
+                for aml in svl.account_move_id.line_ids:
                     if aml.account_id.code and aml.account_id.code[0] in ["2", "3"]:
-                        if round(aml.balance, 2) == round(svl.value, 2):
-                            account = aml.account_id
-                            break
+                        by_account[aml.account_id] = (
+                            by_account.get(aml.account_id, 0.0) + aml.balance
+                        )
+                for acc in sorted(by_account, key=lambda a: a.code or ""):
+                    if round(by_account[acc], 2) == round(svl.value, 2):
+                        account = acc
+                        break
             if svl._l10n_ro_can_use_invoice_line_account(account):
                 if (
                     svl.l10n_ro_valued_type in ("reception", "reception_return")

--- a/l10n_ro_stock_account/tests/test_account_determination.py
+++ b/l10n_ro_stock_account/tests/test_account_determination.py
@@ -132,3 +132,47 @@ class TestStockAccountDetermination(TestStockCommon):
         picking_type_in = self.warehouse_1.in_type_id
         self.create_po(picking_type_in=picking_type_in)
         self.check_stock_valuation(self.val_p1_i, self.val_p2_i, self.account_371_1)
+
+    def test_account_determination_multiline_same_account(self):
+        """A posting can impact a single stock account through several lines
+        whose individual balances don't equal ``svl.value``, only their sum
+        does (e.g. a landed cost split between capitalizing on remaining
+        stock and expensing to 607 the part already sold, both legs hitting
+        the SAME stock account). ``_compute_account`` must match on the
+        account's aggregated balance, not bail out to the category's default
+        account just because no single line matches on its own.
+        """
+        self.create_po()
+        move = self.picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_1
+        )
+
+        target_account = self.account_valuation.copy({"name": "371999"})
+        journal = self.env["account.journal"].search(
+            [("type", "=", "general"), ("company_id", "=", self.env.company.id)],
+            limit=1,
+        )
+        account_move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": journal.id,
+                "line_ids": [
+                    (0, 0, {"account_id": target_account.id, "credit": 60.0}),
+                    (0, 0, {"account_id": target_account.id, "credit": 40.0}),
+                    (0, 0, {"account_id": self.account_expense.id, "debit": 100.0}),
+                ],
+            }
+        )
+        account_move.action_post()
+
+        svl = self.env["stock.valuation.layer"].create(
+            {
+                "company_id": self.env.company.id,
+                "product_id": self.product_1.id,
+                "stock_move_id": move.id,
+                "quantity": 0.0,
+                "value": -100.0,
+                "account_move_id": account_move.id,
+            }
+        )
+        self.assertEqual(svl.l10n_ro_account_id, target_account)

--- a/l10n_ro_stock_account/tests/test_account_determination.py
+++ b/l10n_ro_stock_account/tests/test_account_determination.py
@@ -143,9 +143,7 @@ class TestStockAccountDetermination(TestStockCommon):
         account just because no single line matches on its own.
         """
         self.create_po()
-        move = self.picking.move_ids.filtered(
-            lambda m: m.product_id == self.product_1
-        )
+        move = self.picking.move_ids.filtered(lambda m: m.product_id == self.product_1)
 
         target_account = self.account_valuation.copy({"name": "371999"})
         journal = self.env["account.journal"].search(


### PR DESCRIPTION
## Summary
- `_compute_account` picked the stock account for a `stock.valuation.layer` by looking for a **single** journal line whose balance exactly equals `svl.value`. Postings that split their impact on the **same** stock account across several lines (e.g. a landed cost that capitalizes part of the cost on remaining stock and expenses to 607 the part already sold, both legs on the same `371.xx`) have no single line matching `svl.value` — only their **sum** does. The match silently failed and fell back to the category's default account, leaving a stock-card residual on the wrong (generic) account even though the accounting itself was correct.
- Fix: group class 2/3 lines by account and match on the **aggregated** balance instead of a single line's balance.

## Real-world case (DATUS, ticket 8136)
A landed cost applied via `l10n_ro_stock_account_landed_cost_account` posted two lines on `371.11`: `+858.69` (capitalize on remaining stock) and `-42.93` (expense to `607.11` the part already sold). Neither line individually equals the layer's value (`+815.76`), only their sum does — so the layer's `l10n_ro_account_id` fell back to the generic "371 Merchandise" account instead of `371.11`, producing a phantom stock-card residual with zero actual accounting impact.

## Test plan
- [x] Added `test_account_determination_multiline_same_account` — constructs a journal entry with two lines on the same account whose sum (not either individually) matches the layer's value; asserts the layer resolves to that account.
- [x] Confirmed the new test **fails** on the old code (`account.account(1442,) != account.account(1845,)`) and **passes** with the fix.
- [x] Full `l10n_ro_stock_account` suite: 31/31 passing.
- [x] `l10n_ro_stock_account_landed_cost_account` (most directly relevant — landed cost + account routing): 5/5 passing.
- [x] `l10n_ro_stock_account_notice`: 14/14 passing.
- [x] `l10n_ro_stock_report`: pre-existing, unrelated failure in `test_get_products_with_move` reproduces identically with the fix reverted — not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)