### PR TITLE
[IMP] l10n_ro_message_spv: keep SPV price and description when the product is corrected

### DIFF
--- a/l10n_ro_message_spv/README.rst
+++ b/l10n_ro_message_spv/README.rst
@@ -223,6 +223,23 @@ Configuration
 Changelog
 =========
 
+**19.0.2.7.0 (2026-07-28)**
+
+- The product can now be corrected on a bill line imported from SPV
+  without losing the data received from the supplier: the description
+  and the unit price read from the XML are kept when a different product
+  is selected. Previously the description was overwritten with the
+  product name as soon as the product changed on bills fetched by the
+  standard ``l10n_ro_edi`` SPV import (those bills carry
+  ``l10n_ro_edi_index``, not ``l10n_ro_edi_download``, so the former
+  guard did not apply to them).
+- The guard is now evaluated per line instead of per bill: lines added
+  by hand on an SPV bill are filled in from the product as usual, while
+  the imported lines keep their SPV values.
+- The vendor item code received from SPV is available as an optional
+  column on the bill lines, so the user can see what the supplier
+  invoiced while correcting the product.
+
 **19.0.2.1.2 (2026-07-09)**
 
 - Fixed duplicate vendor bills when a bill already exists in Odoo (e.g.

--- a/l10n_ro_message_spv/__manifest__.py
+++ b/l10n_ro_message_spv/__manifest__.py
@@ -16,7 +16,7 @@
         "wizard/res_config_settings_views.xml",
     ],
     "license": "AGPL-3",
-    "version": "19.0.2.6.0",
+    "version": "19.0.2.7.0",
     "author": "Terrabit,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-romania",
     "installable": True,

--- a/l10n_ro_message_spv/models/account_move.py
+++ b/l10n_ro_message_spv/models/account_move.py
@@ -100,24 +100,56 @@ class AccountMove(models.Model):
                     move.show_reset_to_draft_button = True
         return res
 
+    def _l10n_ro_is_spv_bill(self):
+        """Vendor bill whose content was imported from an SPV XML.
+
+        Both SPV stacks are covered: bills created by this module
+        (``l10n_ro_edi_download``) and bills created by the standard
+        ``l10n_ro_edi`` SPV fetch (``l10n_ro_edi_index``).
+        """
+        self.ensure_one()
+        if self.move_type not in self.get_purchase_types():
+            return False
+        return bool(
+            self.l10n_ro_edi_download
+            or self.l10n_ro_edi_transaction
+            or self.l10n_ro_edi_index
+            or self.l10n_ro_message_spv_ids
+        )
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     l10n_ro_vendor_code = fields.Char(string="Vendor Code", copy=False)
 
+    def _l10n_ro_is_spv_imported_line(self):
+        """Line brought in from the SPV XML, as opposed to one keyed in by hand.
+
+        The values of such a line (description, unit price) are the ones the
+        supplier legally issued, so they must survive the user correcting the
+        product. Lines added manually on the same bill keep the standard Odoo
+        behaviour.
+        """
+        self.ensure_one()
+        move = self.move_id
+        if not move or not move._l10n_ro_is_spv_bill():
+            return False
+        # ``is_imported`` is set by the core on every line created from an
+        # imported attachment; the vendor code covers lines imported before
+        # this flag existed.
+        return bool(self.is_imported or self.l10n_ro_vendor_code)
+
     def _compute_name(self):
+        # Keep the description received from SPV when the product is corrected.
         lines = self.filtered(
-            lambda line: line.move_id.move_type in ["in_invoice", "in_refund"]
-            and line.move_id.l10n_ro_edi_download
+            lambda line: line.name and line._l10n_ro_is_spv_imported_line()
         )
 
         return super(AccountMoveLine, self - lines)._compute_name()
 
     def _compute_price_unit(self):
-        lines = self.filtered(
-            lambda line: line.move_id.move_type in ["in_invoice", "in_refund"]
-            and line.move_id.l10n_ro_edi_download
-        )
+        # Keep the unit price received from SPV when the product is corrected.
+        lines = self.filtered(lambda line: line._l10n_ro_is_spv_imported_line())
 
         return super(AccountMoveLine, self - lines)._compute_price_unit()

--- a/l10n_ro_message_spv/readme/HISTORY.md
+++ b/l10n_ro_message_spv/readme/HISTORY.md
@@ -1,3 +1,20 @@
+**19.0.2.7.0 (2026-07-28)**
+
+- The product can now be corrected on a bill line imported from SPV
+  without losing the data received from the supplier: the description
+  and the unit price read from the XML are kept when a different product
+  is selected. Previously the description was overwritten with the
+  product name as soon as the product changed on bills fetched by the
+  standard `l10n_ro_edi` SPV import (those bills carry
+  `l10n_ro_edi_index`, not `l10n_ro_edi_download`, so the former guard
+  did not apply to them).
+- The guard is now evaluated per line instead of per bill: lines added
+  by hand on an SPV bill are filled in from the product as usual, while
+  the imported lines keep their SPV values.
+- The vendor item code received from SPV is available as an optional
+  column on the bill lines, so the user can see what the supplier
+  invoiced while correcting the product.
+
 **19.0.2.1.2 (2026-07-09)**
 
 - Fixed duplicate vendor bills when a bill already exists in Odoo (e.g.

--- a/l10n_ro_message_spv/static/description/index.html
+++ b/l10n_ro_message_spv/static/description/index.html
@@ -599,6 +599,23 @@ XML-ul a fost validat de sistemul ANAF.</li>
 </div>
 <div class="section" id="changelog">
 <h4><a class="toc-backref" href="#toc-entry-2">Changelog</a></h4>
+<p><strong>19.0.2.7.0 (2026-07-28)</strong></p>
+<ul class="simple">
+<li>The product can now be corrected on a bill line imported from SPV
+without losing the data received from the supplier: the description
+and the unit price read from the XML are kept when a different product
+is selected. Previously the description was overwritten with the
+product name as soon as the product changed on bills fetched by the
+standard <tt class="docutils literal">l10n_ro_edi</tt> SPV import (those bills carry
+<tt class="docutils literal">l10n_ro_edi_index</tt>, not <tt class="docutils literal">l10n_ro_edi_download</tt>, so the former
+guard did not apply to them).</li>
+<li>The guard is now evaluated per line instead of per bill: lines added
+by hand on an SPV bill are filled in from the product as usual, while
+the imported lines keep their SPV values.</li>
+<li>The vendor item code received from SPV is available as an optional
+column on the bill lines, so the user can see what the supplier
+invoiced while correcting the product.</li>
+</ul>
 <p><strong>19.0.2.1.2 (2026-07-09)</strong></p>
 <ul class="simple">
 <li>Fixed duplicate vendor bills when a bill already exists in Odoo (e.g.

--- a/l10n_ro_message_spv/tests/test_message_spv.py
+++ b/l10n_ro_message_spv/tests/test_message_spv.py
@@ -11,7 +11,7 @@ from lxml import etree
 
 from odoo import fields
 from odoo.exceptions import UserError
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 from odoo.tools.misc import file_path
 
 from .common import TestMessageSPV
@@ -1103,3 +1103,147 @@ class TestMessageSPV(TestMessageSPV):
         line_std = invoice_std.invoice_line_ids[0]
         self.assertEqual(line_std.l10n_ro_vendor_code, "VEND_IMPORT_001")
         self.assertEqual(line_std.product_id.id, product.id)
+
+    def _import_spv_bill_with_one_line(self, spv_marker=None):
+        """Bill imported from an SPV XML, holding a single product line.
+
+        `spv_marker` tells which SPV stack created the bill: this module
+        (`l10n_ro_edi_download`) or the standard SPV fetch of `l10n_ro_edi`
+        (`l10n_ro_edi_index`).
+        """
+        xml_content = b"""<?xml version="1.0" encoding="UTF-8"?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:efactura.mfinante.ro:CIUS-RO:1.0.1</cbc:CustomizationID>
+    <cbc:ID>INV_KEEP_001</cbc:ID>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity>2.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="RON">246.9</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>Descriere din SPV</cbc:Name>
+            <cac:SellersItemIdentification>
+                <cbc:ID>VEND_KEEP_001</cbc:ID>
+            </cac:SellersItemIdentification>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="RON">123.45</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>"""
+        attachment = self.env["ir.attachment"].create(
+            {
+                "name": "keep_spv_values.xml",
+                "raw": xml_content,
+                "mimetype": "application/xml",
+            }
+        )
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.vendor.id,
+                # marks the bill as coming from SPV
+                **(spv_marker or {"l10n_ro_edi_download": "3001"}),
+            }
+        )
+        file_data = {
+            "attachment": attachment,
+            "name": attachment.name,
+            "filename": attachment.name,
+            "content": attachment.raw,
+            "mimetype": attachment.mimetype,
+            "type": "xml",
+            "xml_tree": etree.fromstring(attachment.raw),
+        }
+        file_data["import_file_type"] = invoice._get_import_file_type(file_data)
+        invoice._extend_with_attachments([file_data])
+        return invoice
+
+    def test_correct_product_keeps_spv_price_and_description(self):
+        """Correcting the product on an SPV line keeps the imported
+        description and unit price."""
+        invoice = self._import_spv_bill_with_one_line()
+        line = invoice.invoice_line_ids[0]
+        spv_name = line.name
+        self.assertIn("Descriere din SPV", spv_name)
+        self.assertEqual(line.price_unit, 123.45)
+        self.assertTrue(line._l10n_ro_is_spv_imported_line())
+
+        correct_product = self.env["product.product"].create(
+            {
+                "name": "Produsul corect",
+                "description_purchase": "Descriere din fisa produsului",
+                "standard_price": 10.0,
+                "list_price": 10.0,
+            }
+        )
+        line.product_id = correct_product
+
+        self.assertEqual(line.product_id, correct_product)
+        self.assertEqual(line.name, spv_name)
+        self.assertEqual(line.price_unit, 123.45)
+
+    def test_correct_product_keeps_spv_values_on_core_imported_bill(self):
+        """Same protection on bills created by the standard `l10n_ro_edi`
+        SPV fetch, which marks them with `l10n_ro_edi_index`."""
+        invoice = self._import_spv_bill_with_one_line(
+            spv_marker={"l10n_ro_edi_index": "3002"}
+        )
+        line = invoice.invoice_line_ids[0]
+        spv_name = line.name
+        self.assertTrue(line._l10n_ro_is_spv_imported_line())
+
+        correct_product = self.env["product.product"].create(
+            {"name": "Alt produs corect", "standard_price": 7.0}
+        )
+        line.product_id = correct_product
+
+        self.assertEqual(line.name, spv_name)
+        self.assertEqual(line.price_unit, 123.45)
+
+    def test_correct_product_in_form_keeps_spv_price_and_description(self):
+        """Same protection through the form onchange, the way the user
+        actually corrects the product."""
+        invoice = self._import_spv_bill_with_one_line()
+        spv_name = invoice.invoice_line_ids[0].name
+        correct_product = self.env["product.product"].create(
+            {
+                "name": "Produsul corect din form",
+                "description_purchase": "Descriere din fisa produsului",
+                "standard_price": 10.0,
+                "list_price": 10.0,
+            }
+        )
+
+        with Form(invoice) as invoice_form:
+            with invoice_form.invoice_line_ids.edit(0) as line_form:
+                line_form.product_id = correct_product
+                # values seen by the user before saving
+                self.assertEqual(line_form.name, spv_name)
+                self.assertEqual(line_form.price_unit, 123.45)
+
+        line = invoice.invoice_line_ids[0]
+        self.assertEqual(line.product_id, correct_product)
+        self.assertEqual(line.name, spv_name)
+        self.assertEqual(line.price_unit, 123.45)
+
+    def test_manual_line_on_spv_bill_keeps_standard_behaviour(self):
+        """A line keyed in by hand on an SPV bill is filled in from the
+        product, as usual."""
+        invoice = self._import_spv_bill_with_one_line()
+        product = self.env["product.product"].create(
+            {
+                "name": "Produs adaugat manual",
+                "standard_price": 55.0,
+            }
+        )
+        invoice.write(
+            {"invoice_line_ids": [(0, 0, {"product_id": product.id, "quantity": 1})]}
+        )
+        manual_line = invoice.invoice_line_ids.filtered(
+            lambda line: line.product_id == product
+        )
+        self.assertFalse(manual_line._l10n_ro_is_spv_imported_line())
+        self.assertEqual(manual_line.name, "Produs adaugat manual")
+        self.assertEqual(manual_line.price_unit, 55.0)

--- a/l10n_ro_message_spv/views/account_invoice.xml
+++ b/l10n_ro_message_spv/views/account_invoice.xml
@@ -6,6 +6,19 @@
         <field name="type">form</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
+            <!-- Codul de articol al furnizorului, asa cum a venit din XML-ul SPV:
+                 il vede utilizatorul care corecteaza produsul de pe linie. -->
+            <xpath
+                expr="//field[@name='invoice_line_ids']/list/field[@name='name']"
+                position="after"
+            >
+                <field
+                    name="l10n_ro_vendor_code"
+                    optional="hide"
+                    readonly="1"
+                    column_invisible="parent.move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
+                />
+            </xpath>
             <xpath expr="//page[@id='other_tab']" position="after">
                 <page
                     id="l10n_ro_message_spv_ids"


### PR DESCRIPTION
## Problem

On a bill imported from SPV, the description and the unit price are the ones the supplier legally issued. When the user corrects a wrongly matched product on a line, those values must not be replaced by the ones from the product record.

The guard that prevented `_compute_name` / `_compute_price_unit` from overwriting them only recognised bills created by this module (`l10n_ro_edi_download`). Bills fetched by the standard `l10n_ro_edi` SPV import carry `l10n_ro_edi_index` instead, so on those the description was replaced by the product name as soon as the product changed.

The guard was also evaluated per bill rather than per line, so a line added by hand on an SPV bill ended up with no description and a zero price.

## Changes

- `AccountMove._l10n_ro_is_spv_bill()` — recognises both SPV stacks (`l10n_ro_edi_download` / `l10n_ro_edi_transaction` from this module, `l10n_ro_edi_index` from the standard import, plus a linked SPV message).
- `AccountMoveLine._l10n_ro_is_spv_imported_line()` — the guard is now per line, based on the core `is_imported` flag plus `l10n_ro_vendor_code` for lines imported before that flag existed. Lines keyed in by hand on an SPV bill keep the standard Odoo behaviour.
- `_compute_name` / `_compute_price_unit` skip only the SPV-imported lines.
- The vendor item code received from SPV is available as an optional (hidden by default) column on the bill lines, so the user sees what the supplier invoiced while correcting the product.

## Tests

Four new tests: both SPV stacks, the form `onchange` path (`Form`, checking the values both before and after saving) and the manual line falling back to the standard behaviour. The `l10n_ro_edi_index` test was verified to fail against the previous guard.

Full module suite on a RO database: 34 tests, 0 failures.

## Notes

- Taxes: the core already skips `_compute_tax_ids` for `is_imported` lines, so VAT from SPV is preserved on the normal path. Lines imported before that flag existed still recompute their taxes from the product — not addressed here.
- UoM: still recomputed from the product (standard behaviour). Quantity and price are kept, so the subtotal does not move, but the unit shown may differ from the XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)